### PR TITLE
Print more verbose error messages

### DIFF
--- a/scripts/long-description/README.md
+++ b/scripts/long-description/README.md
@@ -9,8 +9,7 @@ Copy [configuration-example.py](configuration-example.py) to configuration.py an
 ### Run with Docker
 ```
 docker build -t long_description .
-docker run -it -v "$PWD":/usr/src/long-description/configuration.py:ro  --name='long_description' long_description
+docker run --rm -it -v "$PWD"/configuration.py:/usr/src/long-description/configuration.py:ro --name='long_description' long_description
 docker cp long_description:/usr/src/long-description/services.json .
 docker rm long_description
 ```
-

--- a/scripts/long-description/long_description.py
+++ b/scripts/long-description/long_description.py
@@ -134,7 +134,7 @@ def get_services_with_long_descriptions(access_token, api_url):
 def delay(api_request_elapsed_seconds):
     if api_request_elapsed_seconds < 1.02:
         delay_seconds = 1.02 - api_request_elapsed_seconds
-        time.sleep(delay_seconds)git
+        time.sleep(delay_seconds)
         
 
 if __name__ == '__main__':

--- a/scripts/long-description/long_description.py
+++ b/scripts/long-description/long_description.py
@@ -130,11 +130,12 @@ def get_services_with_long_descriptions(access_token, api_url):
 
 
 # Delays the script if the API response took a given amount of time
+# Request made a maximum of 59 times per minute
 def delay(api_request_elapsed_seconds):
-    if api_request_elapsed_seconds < 1:
-        delay_seconds = 1 - api_request_elapsed_seconds
-        time.sleep(delay_seconds)
-
+    if api_request_elapsed_seconds < 1.02:
+        delay_seconds = 1.02 - api_request_elapsed_seconds
+        time.sleep(delay_seconds)git
+        
 
 if __name__ == '__main__':
     td_api_url = td_base_url + '/TDWebApi/api'

--- a/scripts/long-description/long_description.py
+++ b/scripts/long-description/long_description.py
@@ -119,6 +119,8 @@ def get_services_with_long_descriptions(access_token, api_url):
         else:
             error = True
             print("Error: " + single_service_url)
+            print("HTTP Status Code: " + str(single_service.status_code))
+            print(single_service.text)
 
         # TD's API allows 60 requests per minute,
         # so we should delay the execution of this loop

--- a/scripts/long-description/long_description.py
+++ b/scripts/long-description/long_description.py
@@ -6,6 +6,9 @@ import sys
 from bs4 import BeautifulSoup
 from configuration import td_base_url, td_api_user, td_api_pass
 
+# Minimum elapsed request time for a maximum of 59 requests made per minute
+request_time_min = 1.02
+
 fields_to_parse = [
     'AccessRequirements', 'AdditionalLinkTitle', 'AdditionalLinkURL',
     'AudienceAssociated', 'AudienceDepartments', 'AudienceDescription',
@@ -130,12 +133,11 @@ def get_services_with_long_descriptions(access_token, api_url):
 
 
 # Delays the script if the API response took a given amount of time
-# Request made a maximum of 59 times per minute
 def delay(api_request_elapsed_seconds):
-    if api_request_elapsed_seconds < 1.02:
-        delay_seconds = 1.02 - api_request_elapsed_seconds
+    if api_request_elapsed_seconds < request_time_min:
+        delay_seconds = request_time_min - api_request_elapsed_seconds
         time.sleep(delay_seconds)
-        
+
 
 if __name__ == '__main__':
     td_api_url = td_base_url + '/TDWebApi/api'


### PR DESCRIPTION
When response code is not 200, print response code and body of response in addition to the URL.